### PR TITLE
fix rounding issue

### DIFF
--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -60,7 +60,7 @@ def round_float(
 
     else:
         # Extract exponent
-        expval = int(np.floor(np.log2(vpos)))
+        expval = math.frexp(vpos)[1] - 1
 
         # Effective precision, accounting for right shift for subnormal values
         if fi.has_subnormals:


### PR DESCRIPTION
Some rounding situations would skip a number due to rounding in `np.log2`.
Using `math.frexp` to extract the exponent fixes this.

Issue:

```py
import gfloat
from gfloat.formats import format_info_bfloat16

a = 6.6461399789245764e+35
b = 6.620178494631905e+35

rounded_a = gfloat.round_float(format_info_bfloat16, a, gfloat.RoundMode.TowardZero)
rounded_b = gfloat.round_float(format_info_bfloat16, b, gfloat.RoundMode.TowardZero)

print("a:                  :", a)
print("b:                  :", b)
print("rounded_a           :", rounded_a)
print("rounded_b           :", rounded_b)

print("b == rounded_b      :", b == rounded_b) # True only if `b` is in the set of BFloat16s

print("(rounded_a < b < a) :", rounded_a < b and b < a) # Rounding skipped `b`
```

Output before:

```txt
a:                  : 6.6461399789245764e+35
b:                  : 6.620178494631905e+35
rounded_a           : 6.594217010339231e+35
rounded_b           : 6.620178494631905e+35
b == rounded_b      : True
(rounded_a < b < a) : True
```

Output after:

```txt
a:                  : 6.6461399789245764e+35
b:                  : 6.620178494631905e+35
rounded_a           : 6.620178494631905e+35
rounded_b           : 6.620178494631905e+35
b == rounded_b      : True
(rounded_a < b < a) : False
```